### PR TITLE
lt03wifi: squashed revert of the new audio HAL

### DIFF
--- a/audio/Android.mk
+++ b/audio/Android.mk
@@ -23,27 +23,17 @@ LOCAL_MODULE_TAGS := optional
 
 LOCAL_SRC_FILES := audio_hw.c ril_interface.c
 
-ifeq ($(BOARD_HDMI_INCAPABLE), true)
-	LOCAL_CFLAGS += -DHDMI_INCAPABLE
-endif
-
 LOCAL_C_INCLUDES += \
-	$(TARGET_OUT_INTERMEDIATES)/KERNEL_OBJ/usr/include \
 	external/tinyalsa/include \
 	$(call include-path-for, audio-effects) \
 	$(call include-path-for, audio-utils) \
 	$(call include-path-for, audio-route)
 
-LOCAL_SHARED_LIBRARIES := \
-	liblog \
-	libcutils \
-	libtinyalsa \
-	libaudioutils \
-	libdl \
-	libaudience_voicefx \
-	libaudioroute
+LOCAL_SHARED_LIBRARIES := liblog libcutils libtinyalsa libaudioutils libdl \
+	libaudience_voicefx libaudioroute
 
 include $(BUILD_SHARED_LIBRARY)
+
 
 # Audience voice preprocessing library
 include $(CLEAR_VARS)

--- a/audio/audio_hw.c
+++ b/audio/audio_hw.c
@@ -1,9 +1,9 @@
 /*
- * Copyright (C) 2012 The Android Open Source Project
- * Copyright (C) 2013-2015 The CyanogenMod Project
+ * Copyright (C) 2011 The Android Open Source Project
+ * Copyright (C) 2012 Wolfson Microelectronics plc
+ * Copyright (C) 2013 The CyanogenMod Project
  *               Daniel Hillenbrand <codeworkx@cyanogenmod.com>
  *               Guillaume "XpLoDWilD" Lesniak <xplodgui@gmail.com>
- *               Andreas Schneider <asn@cryptomilk.org>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,7 +26,7 @@
 #include <stdint.h>
 #include <stdlib.h>
 #include <sys/time.h>
-#include <fcntl.h>
+#include <dlfcn.h>
 
 #include <cutils/log.h>
 #include <cutils/properties.h>
@@ -34,9 +34,6 @@
 
 #include <hardware/audio.h>
 #include <hardware/hardware.h>
-
-#include <linux/videodev2.h>
-#include <linux/videodev2_exynos_media.h>
 
 #include <system/audio.h>
 
@@ -46,37 +43,32 @@
 #include <audio_utils/echo_reference.h>
 #include <audio_route/audio_route.h>
 
+#include "routing.h"
+
 #include "eS325VoiceProcessing.h"
 
-#include "routing.h"
 #include "ril_interface.h"
 
 #define PCM_CARD 0
-#define PCM_CARD_SPDIF 1
-#define PCM_TOTAL 2
+#define PCM_TOTAL 1
 
-#define PCM_DEVICE 0       /* Playback link */
-#define PCM_DEVICE_VOICE 1 /* Baseband link */
-#define PCM_DEVICE_SCO 2   /* Bluetooth link */
-#define PCM_DEVICE_DEEP 3  /* Deep buffer */
+#define PCM_DEVICE 0
+#define PCM_DEVICE_VOICE 1
+#define PCM_DEVICE_SCO 2
+#define PCM_DEVICE_IN 0
 
 #define MIXER_CARD 0
 
-/* duration in ms of volume ramp applied when starting capture to remove plop */
-#define CAPTURE_START_RAMP_MS 100
+#define CAPTURE_START_RAMP_MS 8
 
-/* default sampling for HDMI multichannel output */
-#define HDMI_MULTI_DEFAULT_SAMPLING_RATE 48000
-/* maximum number of channel mask configurations supported. Currently the primary
- * output only supports 1 (stereo) and the multi channel HDMI output 2 (5.1 and 7.1) */
-#define MAX_SUPPORTED_CHANNEL_MASKS 2
+#define MAX_SUPPORTED_CHANNEL_MASKS 1
 
-#define ARRAY_SIZE(a) (sizeof(a) / sizeof((a)[0]))
+#define ARRAY_SIZE(a) (sizeof((a)) / sizeof((a[0])))
 
 struct pcm_config pcm_config_fast = {
     .channels = 2,
     .rate = 48000,
-    .period_size = 256,
+    .period_size = 240,
     .period_count = 2,
     .format = PCM_FORMAT_S16_LE,
 };
@@ -84,15 +76,15 @@ struct pcm_config pcm_config_fast = {
 struct pcm_config pcm_config_deep = {
     .channels = 2,
     .rate = 48000,
-    .period_size = 1024,
-    .period_count = 4,
+    .period_size = 3840,
+    .period_count = 2,
     .format = PCM_FORMAT_S16_LE,
 };
 
 struct pcm_config pcm_config_in = {
     .channels = 2,
     .rate = 48000,
-    .period_size = 1024,
+    .period_size = 240,
     .period_count = 2,
     .format = PCM_FORMAT_S16_LE,
 };
@@ -116,7 +108,7 @@ struct pcm_config pcm_config_sco_wide = {
 struct pcm_config pcm_config_voice = {
     .channels = 2,
     .rate = 8000,
-    .period_size = 1024,
+    .period_size = 960,
     .period_count = 2,
     .format = PCM_FORMAT_S16_LE,
 };
@@ -124,23 +116,14 @@ struct pcm_config pcm_config_voice = {
 struct pcm_config pcm_config_voice_wide = {
     .channels = 2,
     .rate = 16000,
-    .period_size = 1024,
+    .period_size = 960,
     .period_count = 2,
     .format = PCM_FORMAT_S16_LE,
 };
 
-struct pcm_config pcm_config_hdmi_multi = {
-    .channels = 6, /* changed when the stream is opened */
-    .rate = HDMI_MULTI_DEFAULT_SAMPLING_RATE,
-    .period_size = 1024,
-    .period_count = 4,
-    .format = PCM_FORMAT_S16_LE,
-};
-
 enum output_type {
-    OUTPUT_DEEP_BUF,      // deep PCM buffers output stream
-    OUTPUT_LOW_LATENCY,   // low latency output stream
-    OUTPUT_HDMI,          // HDMI multi channel
+    OUTPUT_DEEP_BUF,
+    OUTPUT_LOW_LATENCY,
     OUTPUT_TOTAL
 };
 
@@ -148,7 +131,7 @@ struct audio_device {
     struct audio_hw_device hw_device;
 
     pthread_mutex_t lock;       /* see note below on mutex acquisition order */
-    audio_devices_t out_device; /* "or" of stream_out.device for all active output streams */
+    audio_devices_t out_device;
     audio_devices_t in_device;
     bool mic_mute;
     struct audio_route *ar;
@@ -156,6 +139,13 @@ struct audio_device {
     int cur_route_id;     /* current route ID: combination of input source
                            * and output device IDs */
     audio_mode_t mode;
+
+    /* ES325 */
+    int es325_preset;
+    int es325_new_mode;
+    int es325_mode;
+
+    audio_channel_mask_t in_channel_mask;
 
     /* Call audio */
     struct pcm *pcm_voice_rx;
@@ -171,13 +161,6 @@ struct audio_device {
     bool bluetooth_nrec;
     bool wb_amr;
 
-    int es325_preset;
-    int es325_new_mode;
-    int es325_mode;
-
-    int hdmi_drv_fd;
-    audio_channel_mask_t in_channel_mask;
-
     /* RIL */
     struct ril_handle ril;
 
@@ -187,16 +170,12 @@ struct audio_device {
 struct stream_out {
     struct audio_stream_out stream;
 
-    pthread_mutex_t lock; /* see note below on mutex acquisition order */
+    pthread_mutex_t lock;       /* see note below on mutex acquisition order */
     struct pcm *pcm[PCM_TOTAL];
     struct pcm_config config;
     unsigned int pcm_device;
-    bool standby; /* true if all PCMs are inactive */
+    bool standby;
     audio_devices_t device;
-    /* FIXME: when HDMI multichannel output is active, other outputs must be disabled as
-     * HDMI and WM1811 share the same I2S. This means that notifications and other sounds are
-     * silent when watching a 5.1 movie. */
-    bool disabled;
 
     struct resampler_itfe *resampler;
     struct echo_reference_itfe *echo_reference;
@@ -206,8 +185,6 @@ struct stream_out {
     audio_channel_mask_t channel_mask;
     /* Array of supported channel mask configurations. +1 so that the last entry is always 0 */
     audio_channel_mask_t supported_channel_masks[MAX_SUPPORTED_CHANNEL_MASKS + 1];
-    bool muted;
-    uint64_t written; /* total frames written, not cleared when entering standby */
 
     struct audio_device *dev;
 };
@@ -215,7 +192,7 @@ struct stream_out {
 struct stream_in {
     struct audio_stream_in stream;
 
-    pthread_mutex_t lock; /* see note below on mutex acquisition order */
+    pthread_mutex_t lock;       /* see note below on mutex acquisition order */
     struct pcm *pcm;
     bool standby;
 
@@ -252,27 +229,24 @@ const struct string_to_enum out_channels_name_to_enum_table[] = {
     STRING_TO_ENUM(AUDIO_CHANNEL_OUT_7POINT1),
 };
 
+/* Routing functions */
+
 static int get_output_device_id(audio_devices_t device)
 {
-    if (device == AUDIO_DEVICE_NONE) {
-        ALOGV("%s: AUDIO_DEVICE_NONE\n", __func__);
+    if (device == AUDIO_DEVICE_NONE)
         return OUT_DEVICE_NONE;
-    }
-
-    ALOGV("%s: popcount: %d\n", __func__, popcount(device));
 
     if (popcount(device) == 2) {
         if ((device == (AUDIO_DEVICE_OUT_SPEAKER |
                         AUDIO_DEVICE_OUT_WIRED_HEADSET)) ||
-            (device == (AUDIO_DEVICE_OUT_SPEAKER |
-                        AUDIO_DEVICE_OUT_WIRED_HEADPHONE))) {
+                (device == (AUDIO_DEVICE_OUT_SPEAKER |
+                        AUDIO_DEVICE_OUT_WIRED_HEADPHONE)))
             return OUT_DEVICE_SPEAKER_AND_HEADSET;
-        } else if (device == (AUDIO_DEVICE_OUT_SPEAKER |
-                              AUDIO_DEVICE_OUT_EARPIECE)) {
+        else if (device == (AUDIO_DEVICE_OUT_SPEAKER |
+                        AUDIO_DEVICE_OUT_EARPIECE))
             return OUT_DEVICE_SPEAKER_AND_EARPIECE;
-        } else {
+        else
             return OUT_DEVICE_NONE;
-        }
     }
 
     if (popcount(device) != 1)
@@ -296,7 +270,7 @@ static int get_output_device_id(audio_devices_t device)
     }
 }
 
-static int get_input_source_id(audio_source_t source, bool wb_amr)
+static int get_input_source_id(audio_source_t source)
 {
     switch (source) {
     case AUDIO_SOURCE_DEFAULT:
@@ -310,109 +284,24 @@ static int get_input_source_id(audio_source_t source, bool wb_amr)
     case AUDIO_SOURCE_VOICE_COMMUNICATION:
         return IN_SOURCE_VOICE_COMMUNICATION;
     case AUDIO_SOURCE_VOICE_CALL:
-        ALOGV("%s: AUDIO_SOURCE_VOICE_CALL\n", __func__);
-        if (wb_amr) {
-            return IN_SOURCE_VOICE_CALL_WB;
-        }
         return IN_SOURCE_VOICE_CALL;
     default:
         return IN_SOURCE_NONE;
     }
 }
 
-static int do_out_standby(struct stream_out *out);
 static void adev_set_call_audio_path(struct audio_device *adev);
 
-/**
- * NOTE: when multiple mutexes have to be acquired, always respect the
- * following order: hw device > in stream > out stream
+/*
+ * NOTE: when multiple mutexes have to be acquired, always take the
+ * audio_device mutex first, followed by the stream_in and/or
+ * stream_out mutexes.
  */
-
-/* Helper functions */
-
-static int open_hdmi_driver(struct audio_device *adev)
-{
-    if (adev->hdmi_drv_fd < 0) {
-        adev->hdmi_drv_fd = open("/dev/video16", O_RDWR);
-        if (adev->hdmi_drv_fd < 0)
-            ALOGE("%s cannot open video16 - error: %s\n",
-                  __func__, strerror(errno));
-    }
-    return adev->hdmi_drv_fd;
-}
-
-/* must be called with hw device mutex locked */
-static int enable_hdmi_audio(struct audio_device *adev, int enable)
-{
-    int ret;
-    struct v4l2_control ctrl;
-
-    ret = open_hdmi_driver(adev);
-    if (ret < 0) {
-        return ret;
-    }
-
-    ctrl.id = V4L2_CID_TV_ENABLE_HDMI_AUDIO;
-    ctrl.value = !!enable;
-    ret = ioctl(adev->hdmi_drv_fd, VIDIOC_S_CTRL, &ctrl);
-
-    if (ret < 0) {
-        ALOGE("V4L2_CID_TV_ENABLE_HDMI_AUDIO ioctl error (%d)", errno);
-    }
-
-    return ret;
-}
-
-/* must be called with hw device mutex locked */
-static int read_hdmi_channel_masks(struct audio_device *adev, struct stream_out *out) {
-    int ret;
-    struct v4l2_control ctrl;
-
-    ret = open_hdmi_driver(adev);
-    if (ret < 0)
-        return ret;
-
-    ctrl.id = V4L2_CID_TV_MAX_AUDIO_CHANNELS;
-    ret = ioctl(adev->hdmi_drv_fd, VIDIOC_G_CTRL, &ctrl);
-    if (ret < 0) {
-        ALOGE("V4L2_CID_TV_MAX_AUDIO_CHANNELS ioctl error (%d)", errno);
-        return ret;
-    }
-
-    ALOGV("%s ioctl %d got %d max channels", __func__, ret, ctrl.value);
-
-    if (ctrl.value != 6 && ctrl.value != 8)
-        return -ENOSYS;
-
-    out->supported_channel_masks[0] = AUDIO_CHANNEL_OUT_5POINT1;
-    if (ctrl.value == 8)
-        out->supported_channel_masks[1] = AUDIO_CHANNEL_OUT_7POINT1;
-
-    return ret;
-}
-
-/* must be called with hw device mutex locked */
-static int set_hdmi_channels(struct audio_device *adev, int channels) {
-    int ret;
-    struct v4l2_control ctrl;
-
-    ret = open_hdmi_driver(adev);
-    if (ret < 0)
-        return ret;
-
-    ctrl.id = V4L2_CID_TV_SET_NUM_CHANNELS;
-    ctrl.value = channels;
-    ret = ioctl(adev->hdmi_drv_fd, VIDIOC_S_CTRL, &ctrl);
-    if (ret < 0)
-        ALOGE("V4L2_CID_TV_SET_NUM_CHANNELS ioctl error (%d)", errno);
-
-    return ret;
-}
 
 static void select_devices(struct audio_device *adev)
 {
     int output_device_id = get_output_device_id(adev->out_device);
-    int input_source_id = get_input_source_id(adev->input_source, adev->wb_amr);
+    int input_source_id = get_input_source_id(adev->input_source);
     const char *output_route = NULL;
     const char *input_route = NULL;
     int new_route_id;
@@ -420,29 +309,22 @@ static void select_devices(struct audio_device *adev)
 
     audio_route_reset(adev->ar);
 
-#ifndef HDMI_INCAPABLE
-    enable_hdmi_audio(adev, adev->out_device & AUDIO_DEVICE_OUT_AUX_DIGITAL);
-#endif
-
     new_route_id = (1 << (input_source_id + OUT_DEVICE_CNT)) + (1 << output_device_id);
-    if ((new_route_id == adev->cur_route_id) &&
-        (adev->es325_mode == adev->es325_new_mode)) {
+    if ((new_route_id == adev->cur_route_id) && (adev->es325_mode == adev->es325_new_mode))
         return;
-    }
-
     adev->cur_route_id = new_route_id;
     adev->es325_mode = adev->es325_new_mode;
 
     if (input_source_id != IN_SOURCE_NONE) {
         if (output_device_id != OUT_DEVICE_NONE) {
             input_route =
-                    route_configs[input_source_id][output_device_id]->input_route;
+                route_configs[input_source_id][output_device_id]->input_route;
             output_route =
-                    route_configs[input_source_id][output_device_id]->output_route;
+                route_configs[input_source_id][output_device_id]->output_route;
             new_es325_preset =
                 route_configs[input_source_id][output_device_id]->es325_preset[adev->es325_mode];
         } else {
-            switch (adev->in_device) {
+            switch(adev->in_device) {
             case AUDIO_DEVICE_IN_WIRED_HEADSET & ~AUDIO_DEVICE_BIT_IN:
                 output_device_id = OUT_DEVICE_HEADSET;
                 break;
@@ -453,47 +335,36 @@ static void select_devices(struct audio_device *adev)
                 output_device_id = OUT_DEVICE_SPEAKER;
                 break;
             }
-
             input_route =
-                (route_configs[input_source_id][output_device_id])->input_route;
+                route_configs[input_source_id][output_device_id]->input_route;
             new_es325_preset =
-                (route_configs[input_source_id][output_device_id])->es325_preset[adev->es325_mode];
-        }
-        /*
-         * Disable noise suppression when capturing front and back mic for
-         * voice recognition
-         */
-        if ((adev->input_source == AUDIO_SOURCE_VOICE_RECOGNITION) &&
-            (adev->in_channel_mask == AUDIO_CHANNEL_IN_FRONT_BACK)) {
-            new_es325_preset = -1;
+                route_configs[input_source_id][output_device_id]->es325_preset[adev->es325_mode];
         }
     } else {
         if (output_device_id != OUT_DEVICE_NONE) {
             output_route =
-                    (route_configs[IN_SOURCE_MIC][output_device_id])->output_route;
+                route_configs[IN_SOURCE_MIC][output_device_id]->output_route;
         }
     }
-
-    ALOGV("select_devices() devices: %#x, input src: %d, "
-          "output route: %s input route %s",
+    ALOGV("select_devices() devices %#x input src %d output route %s input route %s",
           adev->out_device, adev->input_source,
           output_route ? output_route : "none",
           input_route ? input_route : "none");
 
-    if (output_route != NULL) {
+    if (output_route)
         audio_route_apply_path(adev->ar, output_route);
-    }
-    if (input_route != NULL) {
+    if (input_route)
         audio_route_apply_path(adev->ar, input_route);
-    }
 
     if ((new_es325_preset != ES325_PRESET_CURRENT) &&
-        (new_es325_preset != adev->es325_preset)) {
+            (new_es325_preset != adev->es325_preset)) {
         ALOGV("  select_devices() changing es325 preset from %d to %d",
               adev->es325_preset, new_es325_preset);
+
         if (eS325_UsePreset(new_es325_preset) == 0) {
             adev->es325_preset = new_es325_preset;
         }
+
     }
 
     audio_route_update_mixer(adev->ar);
@@ -501,57 +372,35 @@ static void select_devices(struct audio_device *adev)
     adev_set_call_audio_path(adev);
 }
 
-static void force_non_hdmi_out_standby(struct audio_device *adev)
-{
-    enum output_type type;
-    struct stream_out *out;
+/* BT SCO functions */
 
-    for (type = 0; type < OUTPUT_TOTAL; ++type) {
-        out = adev->outputs[type];
-        if (type == OUTPUT_HDMI || !out)
-            continue;
-        pthread_mutex_lock(&out->lock);
-        do_out_standby(out);
-        pthread_mutex_unlock(&out->lock);
-    }
-}
-
-/**********************************************************
- * BT SCO functions
- **********************************************************/
-
-/* must be called with the hw device mutex locked, OK to hold other mutexes */
+/* must be called with hw device mutex locked, OK to hold other mutexes */
 static void start_bt_sco(struct audio_device *adev)
 {
     struct pcm_config *sco_config;
 
-    if (adev->pcm_sco_rx != NULL || adev->pcm_sco_tx != NULL) {
+    if (adev->pcm_sco_rx || adev->pcm_sco_tx) {
         ALOGW("%s: SCO PCMs already open!\n", __func__);
         return;
     }
 
     ALOGV("%s: Opening SCO PCMs", __func__);
 
-    if (adev->wb_amr) {
+    if (adev->wb_amr)
         sco_config = &pcm_config_sco_wide;
-    } else {
+    else
         sco_config = &pcm_config_sco;
-    }
 
-    adev->pcm_sco_rx = pcm_open(PCM_CARD,
-                                PCM_DEVICE_SCO,
-                                PCM_OUT,
-                                sco_config);
-    if (adev->pcm_sco_rx != NULL && !pcm_is_ready(adev->pcm_sco_rx)) {
+    adev->pcm_sco_rx = pcm_open(PCM_CARD, PCM_DEVICE_SCO, PCM_OUT,
+            sco_config);
+    if (adev->pcm_sco_rx && !pcm_is_ready(adev->pcm_sco_rx)) {
         ALOGE("%s: cannot open PCM SCO RX stream: %s",
               __func__, pcm_get_error(adev->pcm_sco_rx));
         goto err_sco_rx;
     }
 
-    adev->pcm_sco_tx = pcm_open(PCM_CARD,
-                                PCM_DEVICE_SCO,
-                                PCM_IN,
-                                sco_config);
+    adev->pcm_sco_tx = pcm_open(PCM_CARD, PCM_DEVICE_SCO, PCM_IN,
+            sco_config);
     if (adev->pcm_sco_tx && !pcm_is_ready(adev->pcm_sco_tx)) {
         ALOGE("%s: cannot open PCM SCO TX stream: %s",
               __func__, pcm_get_error(adev->pcm_sco_tx));
@@ -569,64 +418,55 @@ err_sco_rx:
     pcm_close(adev->pcm_sco_rx);
 }
 
-/* must be called with the hw device mutex locked, OK to hold other mutexes */
-static void stop_bt_sco(struct audio_device *adev) {
+/* must be called with hw device mutex locked, OK to hold other mutexes */
+static void end_bt_sco(struct audio_device *adev)
+{
     ALOGV("%s: Closing SCO PCMs", __func__);
 
-    if (adev->pcm_sco_rx != NULL) {
+    if (adev->pcm_sco_rx) {
         pcm_stop(adev->pcm_sco_rx);
         pcm_close(adev->pcm_sco_rx);
         adev->pcm_sco_rx = NULL;
     }
 
-    if (adev->pcm_sco_tx != NULL) {
+    if (adev->pcm_sco_tx) {
         pcm_stop(adev->pcm_sco_tx);
         pcm_close(adev->pcm_sco_tx);
         adev->pcm_sco_tx = NULL;
     }
 }
 
-/**********************************************************
- * Samsung RIL functions
- **********************************************************/
+/* Samsung RIL functions */
 
-/*
- * This function must be called with hw device mutex locked, OK to hold other
- * mutexes
- */
+/* must be called with hw device mutex locked, OK to hold other mutexes */
 static int start_voice_call(struct audio_device *adev)
 {
     struct pcm_config *voice_config;
 
-    if (adev->pcm_voice_rx != NULL || adev->pcm_voice_tx != NULL) {
+    if (adev->pcm_voice_rx || adev->pcm_voice_tx) {
         ALOGW("%s: Voice PCMs already open!\n", __func__);
         return 0;
     }
 
     ALOGV("%s: Opening voice PCMs", __func__);
 
-    if (adev->wb_amr) {
+    if (adev->wb_amr)
         voice_config = &pcm_config_voice_wide;
-    } else {
+    else
         voice_config = &pcm_config_voice;
-    }
 
     /* Open modem PCM channels */
-    adev->pcm_voice_rx = pcm_open(PCM_CARD,
-                                  PCM_DEVICE_VOICE,
-                                  PCM_OUT,
-                                  voice_config);
-    if (adev->pcm_voice_rx != NULL && !pcm_is_ready(adev->pcm_voice_rx)) {
+    adev->pcm_voice_rx = pcm_open(PCM_CARD, PCM_DEVICE_VOICE, PCM_OUT,
+            voice_config);
+    if (adev->pcm_voice_rx && !pcm_is_ready(adev->pcm_voice_rx)) {
         ALOGE("%s: cannot open PCM voice RX stream: %s",
               __func__, pcm_get_error(adev->pcm_voice_rx));
         goto err_voice_rx;
     }
 
-    adev->pcm_voice_tx = pcm_open(PCM_CARD,
-                                  PCM_DEVICE_VOICE,
-                                  PCM_IN,
-                                  voice_config);
-    if (adev->pcm_voice_tx != NULL && !pcm_is_ready(adev->pcm_voice_tx)) {
+    adev->pcm_voice_tx = pcm_open(PCM_CARD, PCM_DEVICE_VOICE, PCM_IN,
+            voice_config);
+    if (adev->pcm_voice_tx && !pcm_is_ready(adev->pcm_voice_tx)) {
         ALOGE("%s: cannot open PCM voice TX stream: %s",
               __func__, pcm_get_error(adev->pcm_voice_tx));
         goto err_voice_tx;
@@ -647,11 +487,8 @@ err_voice_rx:
     return -ENOMEM;
 }
 
-/*
- * This function must be called with hw device mutex locked, OK to hold other
- * mutexes
- */
-static void stop_voice_call(struct audio_device *adev)
+/* must be called with hw device mutex locked, OK to hold other mutexes */
+static void end_voice_call(struct audio_device *adev)
 {
     ALOGV("%s: Closing voice PCMs", __func__);
 
@@ -672,23 +509,22 @@ static void adev_set_wb_amr_callback(void *data, int enable)
 {
     struct audio_device *adev = (struct audio_device *)data;
 
-    pthread_mutex_lock(&adev->lock);
+    ALOGV("%s: setting to: %d", __func__, enable);
 
+    pthread_mutex_lock(&adev->lock);
     if (adev->wb_amr != enable) {
         adev->wb_amr = enable;
 
         /* reopen the modem PCMs at the new rate */
         if (adev->in_call) {
-            ALOGV("%s: %s Incall Wide Band support",
-                  __func__,
-                  enable ? "Turn on" : "Turn off");
-
-            stop_voice_call(adev);
+#if 0
+            /* TODO: set rate properly */
+            end_voice_call(adev);
             select_devices(adev);
             start_voice_call(adev);
+#endif
         }
     }
-
     pthread_mutex_unlock(&adev->lock);
 }
 
@@ -696,14 +532,12 @@ static void adev_set_call_audio_path(struct audio_device *adev)
 {
     enum ril_audio_path device_type;
 
-    ALOGV("%s: out_device=0x%08x", __func__, adev->out_device);
-
     switch(adev->out_device) {
         case AUDIO_DEVICE_OUT_SPEAKER:
             device_type = SOUND_AUDIO_PATH_SPEAKER;
             break;
         case AUDIO_DEVICE_OUT_EARPIECE:
-            device_type = SOUND_AUDIO_PATH_EARPIECE;
+            device_type = SOUND_AUDIO_PATH_HANDSET;
             break;
         case AUDIO_DEVICE_OUT_WIRED_HEADSET:
             device_type = SOUND_AUDIO_PATH_HEADSET;
@@ -722,62 +556,29 @@ static void adev_set_call_audio_path(struct audio_device *adev)
             break;
         default:
             /* if output device isn't supported, use handset by default */
-            device_type = SOUND_AUDIO_PATH_EARPIECE;
+            device_type = SOUND_AUDIO_PATH_HANDSET;
             break;
     }
 
     ALOGV("%s: ril_set_call_audio_path(%d)", __func__, device_type);
-
-    /* TODO: Figure out which devices need EXTRA_VOLUME_PATH set */
-    ril_set_call_audio_path(&adev->ril, device_type, ORIGINAL_PATH);
+    ril_set_call_audio_path(&adev->ril, device_type);
 }
 
-/* must be called with hw device and output stream mutexes locked */
+/* Helper functions */
+
 static int start_output_stream(struct stream_out *out)
 {
     struct audio_device *adev = out->dev;
 
     ALOGV("%s: starting stream", __func__);
 
-    if (out == adev->outputs[OUTPUT_HDMI]) {
-        force_non_hdmi_out_standby(adev);
-    } else if (adev->outputs[OUTPUT_HDMI] && !adev->outputs[OUTPUT_HDMI]->standby) {
-        out->disabled = true;
-        return 0;
-    }
-
-    out->disabled = false;
-
-    if (out->device & (AUDIO_DEVICE_OUT_SPEAKER |
-                       AUDIO_DEVICE_OUT_WIRED_HEADSET |
-                       AUDIO_DEVICE_OUT_WIRED_HEADPHONE |
-                       AUDIO_DEVICE_OUT_AUX_DIGITAL |
-                       AUDIO_DEVICE_OUT_ALL_SCO)) {
-
-        out->pcm[PCM_CARD] = pcm_open(PCM_CARD,
-                                      out->pcm_device,
-                                      PCM_OUT | PCM_MONOTONIC,
-                                      &out->config);
-        if (out->pcm[PCM_CARD] && !pcm_is_ready(out->pcm[PCM_CARD])) {
-            ALOGE("pcm_open(PCM_CARD) failed: %s",
-                  pcm_get_error(out->pcm[PCM_CARD]));
-            pcm_close(out->pcm[PCM_CARD]);
-            return -ENOMEM;
-        }
-    }
-
-    if (out->device & AUDIO_DEVICE_OUT_DGTL_DOCK_HEADSET) {
-        out->pcm[PCM_CARD_SPDIF] = pcm_open(PCM_CARD_SPDIF,
-                                            out->pcm_device,
-                                            PCM_OUT | PCM_MONOTONIC,
-                                            &out->config);
-        if (out->pcm[PCM_CARD_SPDIF] &&
-                !pcm_is_ready(out->pcm[PCM_CARD_SPDIF])) {
-            ALOGE("pcm_open(PCM_CARD_SPDIF) failed: %s",
-                  pcm_get_error(out->pcm[PCM_CARD_SPDIF]));
-            pcm_close(out->pcm[PCM_CARD_SPDIF]);
-            return -ENOMEM;
-        }
+    out->pcm[PCM_CARD] = pcm_open(PCM_CARD, out->pcm_device,
+                                  PCM_OUT, &out->config);
+    if (out->pcm[PCM_CARD] && !pcm_is_ready(out->pcm[PCM_CARD])) {
+        ALOGE("pcm_open(PCM_CARD) failed: %s",
+                pcm_get_error(out->pcm[PCM_CARD]));
+        pcm_close(out->pcm[PCM_CARD]);
+        return -ENOMEM;
     }
 
     /* in call routing must go through set_parameters */
@@ -786,15 +587,10 @@ static int start_output_stream(struct stream_out *out)
         select_devices(adev);
     }
 
-    if (out->device & AUDIO_DEVICE_OUT_ALL_SCO) {
+    if (out->device & AUDIO_DEVICE_OUT_ALL_SCO)
         start_bt_sco(adev);
-    }
 
-    if (out->device & AUDIO_DEVICE_OUT_AUX_DIGITAL) {
-        set_hdmi_channels(adev, out->config.channels);
-    }
-
-    ALOGV("%s: stream out device: 0x%08x, actual: 0x%08x",
+    ALOGV("%s: stream out device: %d, actual: %d",
           __func__, out->device, adev->out_device);
 
     return 0;
@@ -805,10 +601,8 @@ static int start_input_stream(struct stream_in *in)
 {
     struct audio_device *adev = in->dev;
 
-    in->pcm = pcm_open(PCM_CARD,
-                       PCM_DEVICE,
-                       PCM_IN,
-                       &pcm_config_in);
+    in->pcm = pcm_open(PCM_CARD, PCM_DEVICE_IN, PCM_IN, &pcm_config_in);
+
     if (in->pcm && !pcm_is_ready(in->pcm)) {
         ALOGE("pcm_open() failed: %s", pcm_get_error(in->pcm));
         pcm_close(in->pcm);
@@ -816,9 +610,8 @@ static int start_input_stream(struct stream_in *in)
     }
 
     /* if no supported sample rate is available, use the resampler */
-    if (in->resampler) {
+    if (in->resampler)
         in->resampler->reset(in->resampler);
-    }
 
     in->frames_in = 0;
     /* in call routing must go through set_parameters */
@@ -831,9 +624,8 @@ static int start_input_stream(struct stream_in *in)
         select_devices(adev);
     }
 
-    if (in->device & AUDIO_DEVICE_IN_BLUETOOTH_SCO_HEADSET) {
+    if (in->device & AUDIO_DEVICE_IN_BLUETOOTH_SCO_HEADSET)
         start_bt_sco(adev);
-    }
 
     /* initialize volume ramp */
     in->ramp_frames = (CAPTURE_START_RAMP_MS * in->requested_rate) / 1000;
@@ -866,9 +658,8 @@ static int get_next_buffer(struct resampler_buffer_provider *buffer_provider,
     struct stream_in *in;
     size_t i;
 
-    if (buffer_provider == NULL || buffer == NULL) {
+    if (buffer_provider == NULL || buffer == NULL)
         return -EINVAL;
-    }
 
     in = (struct stream_in *)((char *)buffer_provider -
                                    offsetof(struct stream_in, buf_provider));
@@ -902,8 +693,7 @@ static int get_next_buffer(struct resampler_buffer_provider *buffer_provider,
     buffer->frame_count = (buffer->frame_count > in->frames_in) ?
                                 in->frames_in : buffer->frame_count;
     buffer->i16 = in->buffer +
-            (pcm_config_in.period_size - in->frames_in) *
-                popcount(in->channel_mask);
+            (pcm_config_in.period_size - in->frames_in) * popcount(in->channel_mask);
 
     return in->read_status;
 
@@ -928,7 +718,7 @@ static void release_buffer(struct resampler_buffer_provider *buffer_provider,
 static ssize_t read_frames(struct stream_in *in, void *buffer, ssize_t frames)
 {
     ssize_t frames_wr = 0;
-    size_t frame_size = audio_stream_in_frame_size(&in->stream);
+    size_t frame_size = audio_stream_frame_size(&in->stream.common);
 
     while (frames_wr < frames) {
         size_t frames_rd = frames - frames_wr;
@@ -981,7 +771,7 @@ static size_t out_get_buffer_size(const struct audio_stream *stream)
     struct stream_out *out = (struct stream_out *)stream;
 
     return out->config.period_size *
-           audio_stream_out_frame_size((const struct audio_stream_out *)stream);
+            audio_stream_frame_size((struct audio_stream *)stream);
 }
 
 static audio_channel_mask_t out_get_channels(const struct audio_stream *stream)
@@ -1040,15 +830,16 @@ static int do_out_standby(struct stream_out *out)
         }
         out->standby = true;
 
+#if 0
         if (out == adev->outputs[OUTPUT_HDMI]) {
             /* force standby on low latency output stream so that it can reuse HDMI driver if
-             * necessary when restarted */
+            * necessary when restarted */
             force_non_hdmi_out_standby(adev);
         }
+#endif
 
-        if (out->device & AUDIO_DEVICE_OUT_ALL_SCO) {
-            stop_bt_sco(adev);
-        }
+        if (out->device & AUDIO_DEVICE_OUT_ALL_SCO)
+            end_bt_sco(adev);
 
         /* re-calculate the set of active devices from other streams */
         adev->out_device = output_devices(out);
@@ -1057,7 +848,6 @@ static int do_out_standby(struct stream_out *out)
         if (adev->out_device)
             select_devices(adev);
     }
-
     return 0;
 }
 
@@ -1073,7 +863,6 @@ static int out_standby(struct audio_stream *stream)
 
     pthread_mutex_unlock(&out->lock);
     pthread_mutex_unlock(&out->dev->lock);
-
     return ret;
 }
 
@@ -1099,22 +888,12 @@ static int out_set_parameters(struct audio_stream *stream, const char *kvpairs)
                             value, sizeof(value));
     if (ret >= 0) {
         val = atoi(value);
-
         pthread_mutex_lock(&adev->lock);
         pthread_mutex_lock(&out->lock);
-
-        if ((out->device != val) && (val != 0)) {
-            /* Force standby if moving to/from SPDIF or if the output
-             * device changes when in SPDIF mode */
-            if (((val & AUDIO_DEVICE_OUT_DGTL_DOCK_HEADSET) ^
-                 (adev->out_device & AUDIO_DEVICE_OUT_DGTL_DOCK_HEADSET)) ||
-                (adev->out_device & AUDIO_DEVICE_OUT_DGTL_DOCK_HEADSET)) {
-                do_out_standby(out);
-            }
-
-            /* force output standby to start or stop SCO pcm stream if needed */
+        if (((adev->out_device) != val) && (val != 0)) {
+            /* force output standby to stop SCO pcm stream if needed */
             if ((val & AUDIO_DEVICE_OUT_ALL_SCO) ^
-                (out->device & AUDIO_DEVICE_OUT_ALL_SCO)) {
+                    (out->device & AUDIO_DEVICE_OUT_ALL_SCO)) {
                 do_out_standby(out);
             }
 
@@ -1122,19 +901,10 @@ static int out_set_parameters(struct audio_stream *stream, const char *kvpairs)
             adev->out_device = val;
             select_devices(adev);
 
-            if (!out->standby && (out == adev->outputs[OUTPUT_HDMI] ||
-                !adev->outputs[OUTPUT_HDMI] ||
-                adev->outputs[OUTPUT_HDMI]->standby)) {
-                adev->out_device = output_devices(out) | val;
-                select_devices(adev);
-            }
-
             /* start SCO stream if needed */
-            if (val & AUDIO_DEVICE_OUT_ALL_SCO) {
+            if (val & AUDIO_DEVICE_OUT_ALL_SCO)
                 start_bt_sco(adev);
-            }
         }
-
         pthread_mutex_unlock(&out->lock);
         pthread_mutex_unlock(&adev->lock);
     }
@@ -1143,7 +913,7 @@ static int out_set_parameters(struct audio_stream *stream, const char *kvpairs)
     return ret;
 }
 
-static char *out_get_parameters(const struct audio_stream *stream, const char *keys)
+static char * out_get_parameters(const struct audio_stream *stream, const char *keys)
 {
     struct stream_out *out = (struct stream_out *)stream;
     struct str_parms *query = str_parms_create_str(keys);
@@ -1177,7 +947,6 @@ static char *out_get_parameters(const struct audio_stream *stream, const char *k
     } else {
         str = strdup(keys);
     }
-
     str_parms_destroy(query);
     str_parms_destroy(reply);
     return str;
@@ -1194,21 +963,13 @@ static uint32_t out_get_latency(const struct audio_stream_out *stream)
 static int out_set_volume(struct audio_stream_out *stream, float left,
                           float right)
 {
-    struct stream_out *out = (struct stream_out *)stream;
-    struct audio_device *adev = out->dev;
-
-    if (out == adev->outputs[OUTPUT_HDMI]) {
-        /* only take left channel into account: the API is for stereo anyway */
-        out->muted = (left == 0.0f);
-        return 0;
-    }
     return -ENOSYS;
 }
 
 static ssize_t out_write(struct audio_stream_out *stream, const void* buffer,
                          size_t bytes)
 {
-    int ret = 0;
+    int ret;
     struct stream_out *out = (struct stream_out *)stream;
     struct audio_device *adev = out->dev;
     int i;
@@ -1231,29 +992,17 @@ static ssize_t out_write(struct audio_stream_out *stream, const void* buffer,
     }
     pthread_mutex_unlock(&adev->lock);
 
-    if (out->disabled) {
-        ret = -EPIPE;
-        goto exit;
-    }
-
-    if (out->muted)
-        memset((void *)buffer, 0, bytes);
-
     /* Write to all active PCMs */
     for (i = 0; i < PCM_TOTAL; i++)
-        if (out->pcm[i]) {
-            ret = pcm_write(out->pcm[i], (void *)buffer, bytes);
-            if (ret != 0)
-                break;
-        }
-    if (ret == 0)
-        out->written += bytes / (out->config.channels * sizeof(short));
+        if (out->pcm[i])
+           pcm_write(out->pcm[i], (void *)buffer, bytes);
+
 
 exit:
     pthread_mutex_unlock(&out->lock);
 
     if (ret != 0) {
-        usleep(bytes * 1000000 / audio_stream_out_frame_size(&stream) /
+        usleep(bytes * 1000000 / audio_stream_frame_size(&stream->common) /
                out_get_sample_rate(&stream->common));
     }
 
@@ -1302,7 +1051,6 @@ static audio_channel_mask_t in_get_channels(const struct audio_stream *stream)
     return in->channel_mask;
 }
 
-
 static size_t in_get_buffer_size(const struct audio_stream *stream)
 {
     struct stream_in *in = (struct stream_in *)stream;
@@ -1331,7 +1079,7 @@ static int do_in_standby(struct stream_in *in)
         in->pcm = NULL;
 
         if (in->device & AUDIO_DEVICE_IN_BLUETOOTH_SCO_HEADSET)
-            stop_bt_sco(adev);
+            end_bt_sco(adev);
 
         in->dev->input_source = AUDIO_SOURCE_DEFAULT;
         in->dev->in_device = AUDIO_DEVICE_NONE;
@@ -1439,20 +1187,18 @@ static void in_apply_ramp(struct stream_in *in, int16_t *buffer, size_t frames)
 
     frames = (frames < in->ramp_frames) ? frames : in->ramp_frames;
 
-    if (in->channel_mask == AUDIO_CHANNEL_IN_MONO)
-        for (i = 0; i < frames; i++)
-        {
+    if (in->channel_mask == AUDIO_CHANNEL_IN_MONO) {
+        for (i = 0; i < frames; i++) {
             buffer[i] = (int16_t)((buffer[i] * vol) >> 16);
             vol += step;
         }
-    else
-        for (i = 0; i < frames; i++)
-        {
+    } else {
+        for (i = 0; i < frames; i++) {
             buffer[2*i] = (int16_t)((buffer[2*i] * vol) >> 16);
             buffer[2*i + 1] = (int16_t)((buffer[2*i + 1] * vol) >> 16);
             vol += step;
         }
-
+    }
 
     in->ramp_vol = vol;
     in->ramp_frames -= frames;
@@ -1464,7 +1210,7 @@ static ssize_t in_read(struct audio_stream_in *stream, void* buffer,
     int ret = 0;
     struct stream_in *in = (struct stream_in *)stream;
     struct audio_device *adev = in->dev;
-    size_t frames_rq = bytes / audio_stream_in_frame_size(&stream);
+    size_t frames_rq = bytes / audio_stream_frame_size(&stream->common);
 
     /*
      * acquiring hw device mutex systematically is useful if a low
@@ -1504,7 +1250,7 @@ static ssize_t in_read(struct audio_stream_in *stream, void* buffer,
 
 exit:
     if (ret < 0)
-        usleep(bytes * 1000000 / audio_stream_in_frame_size(&stream) /
+        usleep(bytes * 1000000 / audio_stream_frame_size(&stream->common) /
                in_get_sample_rate(&stream->common));
 
     pthread_mutex_unlock(&in->lock);
@@ -1559,8 +1305,7 @@ static int adev_open_output_stream(struct audio_hw_device *dev,
                                    audio_devices_t devices,
                                    audio_output_flags_t flags,
                                    struct audio_config *config,
-                                   struct audio_stream_out **stream_out,
-                                   const char *address __unused)
+                                   struct audio_stream_out **stream_out)
 {
     struct audio_device *adev = (struct audio_device *)dev;
     struct stream_out *out;
@@ -1577,26 +1322,9 @@ static int adev_open_output_stream(struct audio_hw_device *dev,
         devices = AUDIO_DEVICE_OUT_SPEAKER;
     out->device = devices;
 
-    if (flags & AUDIO_OUTPUT_FLAG_DIRECT &&
-        devices == AUDIO_DEVICE_OUT_AUX_DIGITAL) {
-        pthread_mutex_lock(&adev->lock);
-        ret = read_hdmi_channel_masks(adev, out);
-        pthread_mutex_unlock(&adev->lock);
-        if (ret != 0)
-            goto err_open;
-        if (config->sample_rate == 0)
-            config->sample_rate = HDMI_MULTI_DEFAULT_SAMPLING_RATE;
-        if (config->channel_mask == 0)
-            config->channel_mask = AUDIO_CHANNEL_OUT_5POINT1;
-        out->channel_mask = config->channel_mask;
-        out->config = pcm_config_hdmi_multi;
-        out->config.rate = config->sample_rate;
-        out->config.channels = popcount(config->channel_mask);
-        out->pcm_device = PCM_DEVICE;
-        type = OUTPUT_HDMI;
-    } else if (flags & AUDIO_OUTPUT_FLAG_DEEP_BUFFER) {
+    if (flags & AUDIO_OUTPUT_FLAG_DEEP_BUFFER) {
         out->config = pcm_config_deep;
-        out->pcm_device = PCM_DEVICE_DEEP;
+        out->pcm_device = PCM_DEVICE;
         type = OUTPUT_DEEP_BUF;
     } else {
         out->config = pcm_config_fast;
@@ -1658,7 +1386,7 @@ static void adev_close_output_stream(struct audio_hw_device *dev,
     out_standby(&stream->common);
     adev = (struct audio_device *)dev;
     pthread_mutex_lock(&adev->lock);
-    for (type = 0; type < OUTPUT_TOTAL; ++type) {
+    for (type = 0; type < OUTPUT_TOTAL; type++) {
         if (adev->outputs[type] == (struct stream_out *) stream) {
             adev->outputs[type] = NULL;
             break;
@@ -1672,25 +1400,48 @@ static int adev_set_parameters(struct audio_hw_device *dev, const char *kvpairs)
 {
     struct audio_device *adev = (struct audio_device *)dev;
     struct str_parms *parms;
+    char *str;
     char value[32];
     int ret;
 
     parms = str_parms_create_str(kvpairs);
-    ret = str_parms_get_str(parms,
-                            AUDIO_PARAMETER_KEY_BT_NREC,
-                            value,
-                            sizeof(value));
+#if 0
+    ret = str_parms_get_str(parms, AUDIO_PARAMETER_KEY_TTY_MODE, value, sizeof(value));
     if (ret >= 0) {
-        if (strcmp(value, AUDIO_PARAMETER_VALUE_ON) == 0) {
-            adev->bluetooth_nrec = true;
-        } else {
-            adev->bluetooth_nrec = false;
+        int tty_mode;
+
+        if (strcmp(value, AUDIO_PARAMETER_VALUE_TTY_OFF) == 0)
+            tty_mode = TTY_MODE_OFF;
+        else if (strcmp(value, AUDIO_PARAMETER_VALUE_TTY_VCO) == 0)
+            tty_mode = TTY_MODE_VCO;
+        else if (strcmp(value, AUDIO_PARAMETER_VALUE_TTY_HCO) == 0)
+            tty_mode = TTY_MODE_HCO;
+        else if (strcmp(value, AUDIO_PARAMETER_VALUE_TTY_FULL) == 0)
+            tty_mode = TTY_MODE_FULL;
+        else
+            return -EINVAL;
+
+        pthread_mutex_lock(&adev->lock);
+        if (tty_mode != adev->tty_mode) {
+            adev->tty_mode = tty_mode;
+            if (adev->mode == AUDIO_MODE_IN_CALL)
+                select_output_device(adev);
         }
+        pthread_mutex_unlock(&adev->lock);
+    }
+#endif
+
+    ret = str_parms_get_str(parms, AUDIO_PARAMETER_KEY_BT_NREC, value, sizeof(value));
+    if (ret >= 0) {
+        if (strcmp(value, AUDIO_PARAMETER_VALUE_ON) == 0)
+            adev->bluetooth_nrec = true;
+        else
+            adev->bluetooth_nrec = false;
     }
 
     ret = str_parms_get_str(parms, "noise_suppression", value, sizeof(value));
     if (ret >= 0) {
-        if (strcmp(value, "on") == 0) {
+        if (strcmp(value, "true") == 0) {
             ALOGV("%s: enabling two mic control", __func__);
             ril_set_two_mic_control(&adev->ril, AUDIENCE, TWO_MIC_SOLUTION_ON);
         } else {
@@ -1703,8 +1454,8 @@ static int adev_set_parameters(struct audio_hw_device *dev, const char *kvpairs)
     return ret;
 }
 
-static char *adev_get_parameters(const struct audio_hw_device *dev,
-                                 const char *keys)
+static char * adev_get_parameters(const struct audio_hw_device *dev,
+                                  const char *keys)
 {
     return strdup("");
 }
@@ -1720,27 +1471,8 @@ static int adev_set_voice_volume(struct audio_hw_device *dev, float volume)
 
     adev->voice_volume = volume;
 
-    if (adev->mode == AUDIO_MODE_IN_CALL) {
-        enum ril_sound_type sound_type;
-
-        switch (adev->out_device) {
-            case AUDIO_DEVICE_OUT_SPEAKER:
-                sound_type = SOUND_TYPE_SPEAKER;
-                break;
-            case AUDIO_DEVICE_OUT_WIRED_HEADSET:
-            case AUDIO_DEVICE_OUT_WIRED_HEADPHONE:
-                sound_type = SOUND_TYPE_HEADSET;
-                break;
-            case AUDIO_DEVICE_OUT_BLUETOOTH_SCO:
-            case AUDIO_DEVICE_OUT_ALL_SCO:
-                sound_type = SOUND_TYPE_BTVOICE;
-                break;
-            default:
-                sound_type = SOUND_TYPE_VOICE;
-        }
-
-        ril_set_call_volume(&adev->ril, sound_type, volume);
-    }
+    if (adev->mode == AUDIO_MODE_IN_CALL)
+        ril_set_call_volume(&adev->ril, SOUND_TYPE_VOICE, volume);
 
     return 0;
 }
@@ -1754,9 +1486,8 @@ static int adev_set_mode(struct audio_hw_device *dev, audio_mode_t mode)
 {
     struct audio_device *adev = (struct audio_device *)dev;
 
-    if (adev->mode == mode) {
+    if (adev->mode == mode)
         return 0;
-    }
 
     pthread_mutex_lock(&adev->lock);
     adev->mode = mode;
@@ -1769,33 +1500,24 @@ static int adev_set_mode(struct audio_hw_device *dev, audio_mode_t mode)
                 adev->out_device = AUDIO_DEVICE_OUT_EARPIECE;
             }
             adev->input_source = AUDIO_SOURCE_VOICE_CALL;
-
             select_devices(adev);
             start_voice_call(adev);
             ril_set_call_clock_sync(&adev->ril, SOUND_CLOCK_START);
             adev_set_voice_volume(&adev->hw_device, adev->voice_volume);
-
             adev->in_call = true;
         }
     } else {
         ALOGV("%s: Leaving IN_CALL mode", __func__);
-
         if (adev->in_call) {
             adev->in_call = false;
-
-            stop_voice_call(adev);
+            end_voice_call(adev);
             ril_set_call_clock_sync(&adev->ril, SOUND_CLOCK_STOP);
-
-            if (adev->out_device & AUDIO_DEVICE_OUT_ALL_SCO) {
-                stop_bt_sco(adev);
-            }
-
+            if (adev->out_device & AUDIO_DEVICE_OUT_ALL_SCO)
+                end_bt_sco(adev);
             adev->input_source = AUDIO_SOURCE_DEFAULT;
-
             select_devices(adev);
         }
     }
-
     pthread_mutex_unlock(&adev->lock);
 
     return 0;
@@ -1804,15 +1526,14 @@ static int adev_set_mode(struct audio_hw_device *dev, audio_mode_t mode)
 static int adev_set_mic_mute(struct audio_hw_device *dev, bool state)
 {
     struct audio_device *adev = (struct audio_device *)dev;
-    enum ril_mute_state mute_state = state ? TX_MUTE : TX_UNMUTE;
+    enum ril_mute_state ril_state = state ? TX_MUTE : TX_UNMUTE;
 
     ALOGV("%s: set mic mute: %d\n", __func__, state);
 
     adev->mic_mute = state;
 
-    if (adev->in_call) {
-        ril_set_mute(&adev->ril, mute_state);
-    }
+    if (adev->in_call)
+        ril_set_mute(&adev->ril, ril_state);
 
     return 0;
 }
@@ -1829,7 +1550,6 @@ static int adev_get_mic_mute(const struct audio_hw_device *dev, bool *state)
 static size_t adev_get_input_buffer_size(const struct audio_hw_device *dev,
                                          const struct audio_config *config)
 {
-
     return get_input_buffer_size(config->sample_rate, config->format,
                                  popcount(config->channel_mask));
 }
@@ -1838,10 +1558,7 @@ static int adev_open_input_stream(struct audio_hw_device *dev,
                                   audio_io_handle_t handle,
                                   audio_devices_t devices,
                                   struct audio_config *config,
-                                  struct audio_stream_in **stream_in,
-                                  audio_input_flags_t flags __unused,
-                                  const char *address __unused,
-                                  audio_source_t source __unused)
+                                  struct audio_stream_in **stream_in)
 {
     struct audio_device *adev = (struct audio_device *)dev;
     struct stream_in *in;
@@ -1856,9 +1573,8 @@ static int adev_open_input_stream(struct audio_hw_device *dev,
     }
 
     in = (struct stream_in *)calloc(1, sizeof(struct stream_in));
-    if (in == NULL) {
+    if (!in)
         return -ENOMEM;
-    }
 
     in->stream.common.get_sample_rate = in_get_sample_rate;
     in->stream.common.set_sample_rate = in_set_sample_rate;
@@ -1884,12 +1600,9 @@ static int adev_open_input_stream(struct audio_hw_device *dev,
     in->device = devices & ~AUDIO_DEVICE_BIT_IN;
     in->io_handle = handle;
     in->channel_mask = config->channel_mask;
-    /* TODO support low latency pcm config -> AUDIO_INPUT_FLAG_FAST */
 
-    in->buffer = malloc(pcm_config_in.period_size *
-                        pcm_config_in.channels *
-                        audio_stream_in_frame_size(&in->stream));
-
+    in->buffer = malloc(pcm_config_in.period_size * pcm_config_in.channels
+                                               * audio_stream_frame_size(&in->stream.common));
     if (!in->buffer) {
         ret = -ENOMEM;
         goto err_malloc;
@@ -1954,10 +1667,6 @@ static int adev_close(hw_device_t *device)
 
     eS325_Release();
 
-    if (adev->hdmi_drv_fd >= 0) {
-        close(adev->hdmi_drv_fd);
-    }
-
     /* RIL */
     ril_close(&adev->ril);
 
@@ -1971,14 +1680,12 @@ static int adev_open(const hw_module_t* module, const char* name,
     struct audio_device *adev;
     int ret;
 
-    if (strcmp(name, AUDIO_HARDWARE_INTERFACE) != 0) {
+    if (strcmp(name, AUDIO_HARDWARE_INTERFACE) != 0)
         return -EINVAL;
-    }
 
     adev = calloc(1, sizeof(struct audio_device));
-    if (adev == NULL) {
+    if (!adev)
         return -ENOMEM;
-    }
 
     adev->hw_device.common.tag = HARDWARE_DEVICE_TAG;
     adev->hw_device.common.version = AUDIO_DEVICE_API_VERSION_2_0;
@@ -2010,7 +1717,6 @@ static int adev_open(const hw_module_t* module, const char* name,
     adev->es325_preset = ES325_PRESET_INIT;
     adev->es325_new_mode = ES325_MODE_LEVEL;
     adev->es325_mode = ES325_MODE_LEVEL;
-    adev->hdmi_drv_fd = -1;
 
     adev->mode = AUDIO_MODE_NORMAL;
     adev->voice_volume = 1.0f;
@@ -2035,7 +1741,7 @@ struct audio_module HAL_MODULE_INFO_SYM = {
         .module_api_version = AUDIO_MODULE_API_VERSION_0_1,
         .hal_api_version = HARDWARE_HAL_API_VERSION,
         .id = AUDIO_HARDWARE_MODULE_ID,
-        .name = "Exynos5433 audio HW HAL",
+        .name = "JA audio HW HAL",
         .author = "The CyanogenMod Project",
         .methods = &hal_module_methods,
     },

--- a/audio/ril_interface.c
+++ b/audio/ril_interface.c
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#define LOG_TAG "audio_hw_primary_ril"
-#define LOG_NDEBUG 0
+#define ALOG_TAG "audio_hw_primary"
+/*#define ALOG_NDEBUG 0*/
 
 #include <dlfcn.h>
 #include <stdlib.h>
@@ -35,7 +35,7 @@ int (*_ril_connect)(void *);
 int (*_ril_is_connected)(void *);
 int (*_ril_disconnect)(void *);
 int (*_ril_set_call_volume)(void *, enum ril_sound_type, int);
-int (*_ril_set_call_audio_path)(void *, enum ril_audio_path, int);
+int (*_ril_set_call_audio_path)(void *, enum ril_audio_path);
 int (*_ril_set_call_clock_sync)(void *, enum ril_clock_state);
 int (*_ril_set_mute)(void *, int);
 int (*_ril_set_two_mic_control)(void *, enum ril_two_mic_device, enum ril_two_mic_state);
@@ -74,7 +74,7 @@ static int ril_connect_if_required(struct ril_handle *ril)
         return 0;
 
     if (_ril_connect(ril->client) != RIL_CLIENT_ERR_SUCCESS) {
-        ALOGE("ril_connect() failed: %s", strerror(errno));
+        ALOGE("ril_connect() failed");
         return -1;
     }
 
@@ -170,14 +170,12 @@ int ril_set_call_volume(struct ril_handle *ril, enum ril_sound_type sound_type,
                                 (int)(volume * ril->volume_steps_max));
 }
 
-int ril_set_call_audio_path(struct ril_handle *ril,
-                            enum ril_audio_path path,
-                            enum ril_extra_volume mode)
+int ril_set_call_audio_path(struct ril_handle *ril, enum ril_audio_path path)
 {
     if (ril_connect_if_required(ril))
         return 0;
 
-    return _ril_set_call_audio_path(ril->client, path, mode);
+    return _ril_set_call_audio_path(ril->client, path);
 }
 
 int ril_set_call_clock_sync(struct ril_handle *ril, enum ril_clock_state state)

--- a/audio/ril_interface.h
+++ b/audio/ril_interface.h
@@ -47,22 +47,12 @@ enum ril_sound_type {
 };
 
 enum ril_audio_path {
-    SOUND_AUDIO_PATH_EARPIECE,
+    SOUND_AUDIO_PATH_HANDSET,
     SOUND_AUDIO_PATH_HEADSET,
     SOUND_AUDIO_PATH_SPEAKER,
     SOUND_AUDIO_PATH_BLUETOOTH,
-    SOUND_AUDIO_PATH_STEREO_BT,
-    SOUND_AUDIO_PATH_HEADPHONE,
     SOUND_AUDIO_PATH_BLUETOOTH_NO_NR,
-    SOUND_AUDIO_PATH_MIC1,
-    SOUND_AUDIO_PATH_MIC2,
-    SOUND_AUDIO_PATH_BLUETOOTH_WB,
-    SOUND_AUDIO_PATH_BLUETOOTH_WB_NO_NR
-};
-
-enum ril_extra_volume {
-    ORIGINAL_PATH,
-    EXTRA_VOLUME_PATH
+    SOUND_AUDIO_PATH_HEADPHONE
 };
 
 enum ril_clock_state {
@@ -94,9 +84,7 @@ int ril_open(struct ril_handle *ril);
 int ril_close(struct ril_handle *ril);
 int ril_set_call_volume(struct ril_handle *ril, enum ril_sound_type sound_type,
                         float volume);
-int ril_set_call_audio_path(struct ril_handle *ril,
-                            enum ril_audio_path path,
-                            enum ril_extra_volume mode);
+int ril_set_call_audio_path(struct ril_handle *ril, enum ril_audio_path path);
 int ril_set_call_clock_sync(struct ril_handle *ril, enum ril_clock_state state);
 int ril_set_mute(struct ril_handle *ril, enum ril_mute_state state);
 void ril_register_set_wb_amr_callback(void *function, void *data);

--- a/audio/routing.h
+++ b/audio/routing.h
@@ -38,7 +38,6 @@ enum {
     IN_SOURCE_VOICE_RECOGNITION,
     IN_SOURCE_VOICE_COMMUNICATION,
     IN_SOURCE_VOICE_CALL,
-    IN_SOURCE_VOICE_CALL_WB,
     IN_SOURCE_TAB_SIZE,            /* number of lines in route_configs[][] */
     IN_SOURCE_NONE,
     IN_SOURCE_CNT
@@ -65,23 +64,9 @@ const struct route_config voice_speaker = {
       ES325_PRESET_OFF }
 };
 
-const struct route_config voice_speaker_wb = {
-    "voice-speaker-wb",
-    "voice-speaker-main-mic-wb",
-    { ES325_PRESET_OFF,
-      ES325_PRESET_OFF }
-};
-
 const struct route_config voice_earpiece = {
     "voice-earpiece",
     "voice-main-mic",
-    { ES325_PRESET_OFF,
-      ES325_PRESET_OFF }
-};
-
-const struct route_config voice_earpiece_wb = {
-    "voice-earpiece-wb",
-    "voice-earpiece-main-mic-wb",
     { ES325_PRESET_OFF,
       ES325_PRESET_OFF }
 };
@@ -93,23 +78,9 @@ const struct route_config voice_headphones = {
       ES325_PRESET_OFF }
 };
 
-const struct route_config voice_headphones_wb = {
-    "voice-headphones-wb",
-    "voice-headphones-main-mic-wb",
-    { ES325_PRESET_OFF,
-      ES325_PRESET_OFF }
-};
-
 const struct route_config voice_headset = {
     "voice-headphones",
     "voice-headset-mic",
-    { ES325_PRESET_OFF,
-      ES325_PRESET_OFF }
-};
-
-const struct route_config voice_headset_wb = {
-    "voice-headphones-wb",
-    "voice-headset-mic-wb",
     { ES325_PRESET_OFF,
       ES325_PRESET_OFF }
 };
@@ -219,13 +190,6 @@ const struct route_config bluetooth_sco = {
       ES325_PRESET_OFF }
 };
 
-const struct route_config bluetooth_sco_wb = {
-    "bt-sco-headset-wb",
-    "bt-sco-mic",
-    { ES325_PRESET_OFF,
-      ES325_PRESET_OFF }
-};
-
 const struct route_config none = {
     "none",
     "none",
@@ -279,15 +243,6 @@ const struct route_config * const route_configs[IN_SOURCE_TAB_SIZE]
         &bluetooth_sco,             /* OUT_DEVICE_BT_SCO */
         &voice_headphones,          /* OUT_DEVICE_SPEAKER_AND_HEADSET */
         &voice_earpiece             /* OUT_DEVICE_SPEAKER_AND_EARPIECE */
-    },
-    {   /* IN_SOURCE_VOICE_CALL_WB */
-        &voice_speaker_wb,          /* OUT_DEVICE_SPEAKER */
-        &voice_earpiece_wb,         /* OUT_DEVICE_EARPIECE */
-        &voice_headset_wb,          /* OUT_DEVICE_HEADSET */
-        &voice_headphones_wb,       /* OUT_DEVICE_HEADPHONES */
-        &bluetooth_sco_wb,          /* OUT_DEVICE_BT_SCO */
-        &voice_headphones_wb,       /* OUT_DEVICE_SPEAKER_AND_HEADSET */
-        &voice_earpiece_wb          /* OUT_DEVICE_SPEAKER_AND_EARPIECE */
     },
 };
 


### PR DESCRIPTION
Revert "lt03wifi: fix audience eS325 include path"

This reverts commit 4dce9336d34f77165be2d96984cb31aa0aa5e744.

Revert "lt03wifi: import audio HAL from trelte"

This reverts commit aaf840868ecb4b2ddc77361e1167d410dd654a75.
